### PR TITLE
(maint) Add compose file for a single puppet master

### DIFF
--- a/single-host/.gitignore
+++ b/single-host/.gitignore
@@ -1,0 +1,4 @@
+code/*
+puppet/*
+puppetdb/*
+puppetdb-postgres/*

--- a/single-host/README.md
+++ b/single-host/README.md
@@ -1,0 +1,36 @@
+# Create a Single Puppet Host with Docker Compose
+
+1. Create an external volume for the postgres database
+
+``` bash
+> docker volume create --name puppetdb-postgres-volume -d local
+```
+
+2. Start the composition
+
+``` bash
+> docker-compose up
+```
+
+3. Wait for a while ...
+
+The initialization process can take a while and may appear to throw errors.  Just wait awhile and eventually all of the components just sort themselves out
+
+4. Put your Puppet code etc. into the `code` directory, as you would with R10K or Puppet Code Manager
+
+
+# Destroy a Single Puppet Host with Docker Compose
+
+1. Stop docker-compose with Ctrl-C
+
+2. Remove the resources with docker-compose
+
+``` bash
+> docker-compose down
+```
+
+3. Remove the volume
+
+``` bash
+> docker volume rm puppetdb-postgres-volume
+```

--- a/single-host/docker-compose.yml
+++ b/single-host/docker-compose.yml
@@ -1,0 +1,90 @@
+version: '2'
+
+services:
+  puppet:
+    image: puppet/puppetserver
+    depends_on:
+      - puppetdb
+    ports:
+      - "8140:8140"
+    volumes:
+      - ./code:/etc/puppetlabs/code/
+      - ./puppet/ssl:/etc/puppetlabs/puppet/ssl/
+      - ./puppet/serverdata:/opt/puppetlabs/server/data/puppetserver/
+    labels:
+    # In some cases unqualified hostnames can have the .local suffix
+    # added, I've seen this under Docker of Mac Beta for instance.
+    # Due to needing to access PuppetDB on same hostame as signed in the # certificate you may need to uncommant the following lines
+    #environment:
+    #  - PUPPETDB_SERVER_URLS=https://puppetdb.local:8081
+    #links:
+    #  - puppetdb:puppetdb.local
+    networks:
+      puppetstack:
+
+  puppetdbpostgres:
+    container_name: postgres
+    image: puppet/puppetdb-postgres
+    environment:
+      - POSTGRES_PASSWORD=puppetdb
+      - POSTGRES_USER=puppetdb
+    expose:
+      - 5432
+    volumes:
+      - puppetdb-postgres-volume:/var/lib/postgresql/data/
+    networks:
+      puppetstack:
+
+  puppetdb:
+    hostname: puppetdb
+    image: puppet/puppetdb
+    ports:
+      - 8080
+      - 8081
+    depends_on:
+      - puppetdbpostgres
+    volumes:
+      - ./puppetdb/ssl:/etc/puppetlabs/puppet/ssl/
+    networks:
+      puppetstack:
+
+  ## summary doesn't work without editing puppet.conf on the server.
+  ##   This is here mostly as an expirement right now.
+  #puppet-summary:
+  #  hostname: puppet-summary
+  #  image: stahnma/puppet-summary
+  #  ports:
+  #   - "3001:3001"
+  #  volumes:
+  #   - ./app:/app
+  #  expose:
+  #  - 3001
+
+  puppetexplorer:
+    image: puppet/puppetexplorer
+    ports:
+      - "80:80"
+    read_only: true
+    networks:
+      puppetstack:
+
+  puppetboard:
+    image: puppet/puppetboard
+    ports:
+      - "8000:8000"
+    networks:
+      puppetstack:
+
+# Top level configuration
+networks:
+  puppetstack:
+
+# An external volume is needed for postgres as when under Docker For Windows the files have a different
+# owner that the starting process.
+# ref: https://forums.docker.com/t/trying-to-get-postgres-to-work-on-persistent-windows-mount-two-issues/12456/4
+#
+# To create the volume use; docker volume create --name puppetdb-postgres-volume -d local
+# To delete the volume use; docker volume rm puppetdb-postgres-volume
+volumes:
+  puppetdb-postgres-volume:
+    external: true


### PR DESCRIPTION
Previously the docker-compose file used a load balancer in front of the
Puppet Master however this was not compatible with running on a Windows host.

* This commit removes the laod balancer and only allows a single Puppet Master
* Uses an external volume for the Postgres database as it will not start on
  Windows hosts due to the file owner being different
* Uses a fixed port for the Puppet Master otherwise agents need to change their
  configuration (masterport setting) whenever the compse stack is restarted